### PR TITLE
Sprint 32 TLT-1959 Modify tool to allow for Canvas course template use

### DIFF
--- a/canvas_course_info/requirements/local.txt
+++ b/canvas_course_info/requirements/local.txt
@@ -2,4 +2,7 @@
 -r aws.txt
 django-debug-toolbar
 mock
+django-sslserver==0.15
 #pep8 flake8
+
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.7#egg=django-icommons-common==1.10.7

--- a/canvas_course_info/requirements/local.txt
+++ b/canvas_course_info/requirements/local.txt
@@ -5,4 +5,4 @@ mock
 django-sslserver==0.15
 #pep8 flake8
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.7#egg=django-icommons-common==1.10.7
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.8#egg=django-icommons-common==1.10.8

--- a/canvas_course_info/settings/aws.py
+++ b/canvas_course_info/settings/aws.py
@@ -61,9 +61,6 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-# Display the button to offer to insert text by default
-OFFER_TEXT = SECURE_SETTINGS.get('offer_text', True)
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 STATIC_URL = '/static/'

--- a/canvas_course_info/settings/local.py
+++ b/canvas_course_info/settings/local.py
@@ -3,7 +3,7 @@
 from .aws import *
 
 ENV_NAME = 'local'
-INSTALLED_APPS += ('debug_toolbar',)
+INSTALLED_APPS += ('debug_toolbar', 'sslserver', 'icommons_common',)
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
 # For Django Debug Toolbar:
@@ -15,5 +15,5 @@ DEBUG_TOOLBAR_CONFIG = {
 
 # Example ID for local dev: won't be getting a real course instance id from LTI launch params.
 COURSE_INSTANCE_ID = SECURE_SETTINGS.get('course_instance_id')
-if COURSE_INSTANCE_ID :
+if COURSE_INSTANCE_ID:
     COURSE_INSTANCE_ID = str(COURSE_INSTANCE_ID)

--- a/course_info/icommons.py
+++ b/course_info/icommons.py
@@ -40,15 +40,25 @@ class ICommonsApi(drest.API):
         course_info = {}
         # get the course_instance data
         try:
-            relative_url = '/course_instances/'+ course_instance_id+'/?format=json'
-            response = self.make_request('GET',relative_url,headers=self.headers)
+            relative_url = '/course_instances/%s/?format=json' % course_instance_id
+            response = self.make_request('GET', relative_url, headers=self.headers)
             course_info = response.data.copy()
-        except drest.exc.dRestRequestError as e:
-            log.error(e.message)
         except Exception as e:
-            log.error(e.message)
+            log.exception(e.message)
         return course_info
 
+    def get_course_info_by_canvas_course_id(self, canvas_course_id):
+        course_info = {}
+        # get the course_instance data
+        try:
+            relative_url = '/course_instances/?format=json&canvas_course_id=%s' % canvas_course_id
+            response = self.make_request('GET', relative_url, headers=self.headers)
+            results = response.data.get('results', [])
+            if len(results):
+                course_info = self.get_course_info(results[0]['course_instance_id'])
+        except Exception as e:
+            log.exception(e.message)
+        return course_info
 
     def get_school_info(self, school_id):
         '''

--- a/course_info/templates/course_info/editor.html
+++ b/course_info/templates/course_info/editor.html
@@ -24,7 +24,7 @@
                 // set up the base url
                 var p = $(location).attr('protocol');
                 var h = $(location).attr('host');
-                var widget_url = p + '//' + h + '/course_info/widget.html?course_instance_id={{ course_instance_id }}';
+                var widget_url = p + '//' + h + '/course_info/widget.html?';
 
                 // Only select once for efficiency's sake
                 var return_type_val = $("#return_type").val();

--- a/course_info/templates/course_info/widget.html
+++ b/course_info/templates/course_info/widget.html
@@ -34,19 +34,14 @@
 {% endcomment %}
 
 {% block content %}
-
     <div id="course_info_container" class="container-fluid">
-
-        <table border="0" cellpadding="0" cellspacing="5">
-            <tbody>
-            {% for field in fields  %}
-                <tr><td class="{{ field.class }}">{% autoescape off %}{{ field.value }}{% endautoescape %}</td></tr>
+        <ul class="list-group" style="width: 50%;">
+            {% for field in fields %}
+            {% if field.value %}
+            <li class="list-group-item {{ field.class }}">{{ field.value|safe }}</li>
+            {% endif %}
             {% endfor %}
-            </tbody>
-        </table>
-
+        </ul>
+        <span class="text-info">Additional information will be shown if available from the Registrar.</span>
     </div>
-
 {% endblock %}
-
-

--- a/course_info/tests.py
+++ b/course_info/tests.py
@@ -18,13 +18,19 @@ class testData(TestCase):
     # Tip: first word in a test method must be "test" for Django to recognize it & run it.
     def test_course_number(self):
         # Make sure that the widget is displaying a correct course number for a given course ID
-        c = Client()
-        response = c.get('/course_info/widget.html?course_instance_id=' + TESTDATA["example_course1"]["id"] + '&f=course.registrar_code_display')
+        canvas_course_id = TESTDATA["example_course1"]["canvas_course_id"]
+        c = Client(
+            HTTP_REFERER="https://canvas.icommons.harvard.edu/courses/%s" % canvas_course_id
+        )
+        response = c.get('/course_info/widget.html?f=course.registrar_code_display')
         self.assertContains(response, TESTDATA["example_course1"]["number_display"])
 
     def test_school_name(self):
-        c = Client()
-        response = c.get('/course_info/widget.html?course_instance_id=' + TESTDATA["example_course1"]["id"] + '&f=course.registrar_code_display')
+        canvas_course_id = TESTDATA["example_course1"]["canvas_course_id"]
+        c = Client(
+            HTTP_REFERER="https://canvas.icommons.harvard.edu/courses/%s" % canvas_course_id
+        )
+        response = c.get('/course_info/widget.html?f=course.registrar_code_display')
         self.assertContains(response, TESTDATA["example_course1"]["school_display"])
 
 
@@ -41,6 +47,7 @@ class testEditor(TestCase):
 TESTDATA = {
     "example_course1" : {
         "id" : "312976",
+        "canvas_course_id": "10000",
         "number_display" : "2901",
         "school_display" : "Harvard Divinity School"
     }

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -39,6 +39,10 @@ def tool_config(request):
         }
     }
 
+    custom_fields = {
+        'include_text_option': 'false'
+    }
+
     lti_tool_config = ToolConfig(
         title=app_config['name'],
         launch_url=launch_url,
@@ -46,6 +50,7 @@ def tool_config(request):
         extensions=extensions,
         description=app_config['description']
     )
+    lti_tool_config.set_ext_param('canvas.instructure.com', 'custom_fields', custom_fields)
 
     return HttpResponse(lti_tool_config.to_xml(), content_type='text/xml')
 
@@ -189,7 +194,7 @@ def editor(request):
     #course_context['line_guestimate'] =keys*2
 
     course_context['launch_presentation_return_url'] = request.POST.get('launch_presentation_return_url')
-    course_context['should_offer_text'] = settings.OFFER_TEXT
+    course_context['should_offer_text'] = request.POST.get('custom_include_text_option', 'false') in ['true']
 
     # scrub HTML tags (just for the editor view)
     # this could also be done in the django template

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -57,71 +57,84 @@ def lti_launch(request):
     return editor(request)
 
 
-def __course_context(request, course_instance_id, keys):
+def __course_context(request, keys, **kwargs):
     key2class = {
-        'title': 'course_info_textHeader1',
-        'course.registrar_code_display': 'course_info_textHeader2',
-        'term.display_name': 'course_info_textHeader2',
-        'instructors_display': 'course_info_textHeader2',
-        'location': 'course_info_textHeader2',
-        'meeting_time': 'course_info_textHeader2'
+        'title': 'list-group-item-info'
     }
-    course_info = ICommonsApi.from_request(request).get_course_info(course_instance_id)
-    context = {'fields': [], 'course_instance_id': course_instance_id}
+    course_instance_id = kwargs.get('course_instance_id')
+    canvas_course_id = kwargs.get('canvas_course_id')
+    course_info = {}
+    if course_instance_id:
+        course_info = ICommonsApi.from_request(request).get_course_info(course_instance_id)
+    elif canvas_course_id:
+        course_info = ICommonsApi.from_request(request).get_course_info_by_canvas_course_id(canvas_course_id)
+    context = {
+        'fields': [],
+        'course_instance_id': course_info.get('course_instance_id'),
+        'canvas_course_id': course_info.get('canvas_course_id')
+    }
     for key in keys:
-        if '.' in key:
-            keyparts = key.split('.')
-            field = {'key': key, 'value': course_info[keyparts[0]][keyparts[1]]}
-        else:
-            field = {'key': key, 'value': course_info[key]}
-        field['class'] = ''
+        try:
+            if '.' in key:
+                keyparts = key.split('.')
+                value = course_info[keyparts[0]][keyparts[1]]
+            else:
+                value = course_info[key]
+        except KeyError:
+            value = ''
+        field = {'key': key, 'value': value, 'class': ''}
         if key in key2class:
             field['class'] = key2class[key]
         context['fields'].append(field)
 
-    school_info = ICommonsApi.from_request(request).get_school_info(course_info['course']['school_id'])
-    context['fields'] = __mungeFields(context['fields'], school_info['title_long'])
+    try:
+        school_info = ICommonsApi.from_request(request).get_school_info(course_info['course']['school_id'])
+        school_title = school_info['title_long']
+    except KeyError:
+        school_title = ''
+
+    context['fields'] = __mungeFields(context['fields'], school_title)
     return context
+
 
 def __mungeFields(fields, school_name):
     # This method takes in all the iCommons fields, and formats those that we'd like to display
     # Could possibly sneak in some more inline styles here
 
     # if we want more info in the logger, could pass in the whole field dictionary and send the key in the log message
-    def stern(value, default):
+    def stern(value, default, label=None):
         # special ternary to simplify the logic below -deals with blank fields
-        if value == u' ' or value == u'' or value == '' or value == ' ':
-            #May want to log some error
-            return default
-        else:
+        if value and value.strip():
+            if label:
+                value = label + value
             return value
+
+        return default
 
     for field in fields:
         if field['key'] == 'title':
-            field['value'] = '<h3>' + field['value'] + "</h3>"
+            field['value'] = "<h4>%s</h4>" % stern(field['value'], "Course Title Unknown")
         elif field['key'] == 'term.display_name':
-            field['value'] = stern(field['value'],"Display Name Unknown") #include this? '<b>Term:</b> '
+            field['value'] = stern(field['value'], "")
         elif field['key'] == 'instructors_display':
-            field['value'] = stern(field['value'], "Course Instructors Unknown") #include this? '<b>Course Instructor(s):</b> '
+            field['value'] = stern(field['value'], "")
         elif field['key'] == 'location':
-            field['value'] = '<b>Location:</b> ' + stern(field['value'], 'Unknown')
+            field['value'] = stern(field['value'], "", "<b>Location:</b> ")
         elif field['key'] == 'meeting_time':
-            field['value'] = '<b>Meeting Time:</b> ' + stern(field['value'], 'Unknown')
+            field['value'] = stern(field['value'], "", "<b>Meeting Time:</b> ")
         elif field['key'] == 'exam_group':
-            field['value'] = '<b>Exam Group: </b> ' + stern(field['value'], 'Unknown')
+            field['value'] = stern(field['value'], "", "<b>Exam Group:</b> ")
         elif field['key'] == 'description':
-            field['value'] = '<b>Course Description:</b> ' + stern(field['value'], 'None')
+            field['value'] = stern(field['value'], "", "<b>Course Description:</b> ")
         elif field['key'] == 'notes':
-            field['value'] = '<b>Note: </b> ' + field['value']
+            field['value'] = stern(field['value'], "", "<b>Notes:</b> ")
         elif field['key'] == 'course.registrar_code_display':
             try:
-                #Extracts the course number (the last substring) from typical display codes
-                course_number = field['value'].split()[-1]
-            except:
-                #If the display code is atypical, show the whole thing. (Unless it's blank)
-                course_number = stern(field['value'], "Course Number Unknown")
-                #May want to log "Registrar Code Atypical/Not Provided"
-            field['value'] = school_name + ": " + course_number
+                # Extracts the course number (the last substring) from typical display codes
+                field['value'] = stern(field['value'].split()[-1], "", school_name + ": ")
+            except IndexError:
+                # If the display code is atypical, show the whole thing
+                field['value'] = stern(field['value'], "", school_name + ": ")
         field['value'] = field['value'].replace('<br /> <br />', '<br />')
 
     return fields
@@ -129,25 +142,21 @@ def __mungeFields(fields, school_name):
 
 @require_GET
 def widget(request):
-    course_instance_id = request.GET.get('course_instance_id')
-    context = __course_context(request, course_instance_id, request.GET.getlist('f'))
+    referer = request.META.get('HTTP_REFERER', '')
+    try:
+        canvas_course_id = re.match('^.+/courses/(?P<canvas_course_id>\d+)(?:$|.+$)', referer).group('canvas_course_id')
+    except AttributeError:
+        canvas_course_id = None
+    context = __course_context(request, request.GET.getlist('f'), canvas_course_id=canvas_course_id)
     return render(request, 'course_info/widget.html', context)
 
+
 def editor(request):
-
-    # Use an example course for development
-    # if settings.COURSE_INSTANCE_ID:
-    #     course_instance_id = settings.COURSE_INSTANCE_ID
-    # else:
-    #     # "lis" appears to be a deliberate misspelling
-    #     course_instance_id = request.POST.get('lis_course_offering_sourcedid')
-    try:
-        course_instance_id = settings.COURSE_INSTANCE_ID
-    except:
-                                # "lis" appears to be a deliberate misspelling
+    # Use an example course for development if one is configured in settings
+    course_instance_id = getattr(settings, 'COURSE_INSTANCE_ID', None)
+    if not course_instance_id:
+        # "lis" appears to be a deliberate misspelling
         course_instance_id = request.POST.get('lis_course_offering_sourcedid')
-
-
 
     # The values we will want to display
     keys = [
@@ -162,7 +171,7 @@ def editor(request):
         'notes'
     ]
 
-    course_context = __course_context(request, course_instance_id, keys)
+    course_context = __course_context(request, keys, course_instance_id=course_instance_id)
 
     # this is likely a remnant of the iFrame resize struggle
     #course_context['line_guestimate'] =keys*2
@@ -197,9 +206,13 @@ def oembed_handler(request):
 
     # get the selected checkboxes and course id
     requested_info = parsed_qs['f']
-    course_instance_id = parsed_qs['course_instance_id'][0]
+    referer = request.META.get('HTTP_REFERER', '')
+    try:
+        canvas_course_id = re.match('^.+/courses/(?P<canvas_course_id>\d+)(?:$|.+$)', referer).group('canvas_course_id')
+    except AttributeError:
+        canvas_course_id = None
 
-    course_info_context = __course_context(request, course_instance_id, requested_info)
+    course_info_context = __course_context(request, requested_info, canvas_course_id=canvas_course_id)
 
     # put the rendered html in a string, so that it can be returned in the oEmbed JSON
     # the content_type = " " is included so there will be a fixed amount of characters to delete later (13)


### PR DESCRIPTION
- Use HTTP Referer header to get canvas course id for looking up course instance info via the iCommons REST API
- Do not show fields if they are not populated
