### PR TITLE
Sprint 32 TLT-2032 Hide registrar message

### DIFF
--- a/course_info/templates/course_info/widget.html
+++ b/course_info/templates/course_info/widget.html
@@ -42,6 +42,8 @@
             {% endif %}
             {% endfor %}
         </ul>
+        {% if show_registrar_fields_message %}
         <span class="text-info">Additional information will be shown if available from the Registrar.</span>
+        {% endif %}
     </div>
 {% endblock %}

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -164,7 +164,12 @@ def widget(request):
         canvas_course_id = re.match('^.+/courses/(?P<canvas_course_id>\d+)(?:$|.+$)', referer).group('canvas_course_id')
     except AttributeError:
         canvas_course_id = None
-    context = __course_context(request, request.GET.getlist('f'), canvas_course_id=canvas_course_id)
+
+    field_names = request.GET.getlist('f')
+    context = __course_context(request, field_names, canvas_course_id=canvas_course_id)
+    populated_fields = [f for f in context['fields'] if f['value']]
+    context['show_registrar_fields_message'] = len(populated_fields) < len(field_names)
+
     return render(request, 'course_info/widget.html', context)
 
 


### PR DESCRIPTION
- Do not show message indicating that fields will show as they are populated by the registrar if all possible fields are already shown
