### PR TITLE
configures logging in order to permit splunk forwarding

### DIFF
--- a/canvas_course_info/settings/local.py
+++ b/canvas_course_info/settings/local.py
@@ -1,6 +1,9 @@
 # to activate these settings, execute ./manage.py runserver --settings=canvas_course_info.settings.local
 
 from .aws import *
+from logging.config import dictConfig
+
+dictConfig(LOGGING)
 
 ENV_NAME = 'local'
 INSTALLED_APPS += ('debug_toolbar', 'sslserver',)


### PR DESCRIPTION
Based on lti_emailer configuration, currently (which is Django 1.8, but appears to work fine with this project).
