### PR TITLE
Task/elliottyates/tlt 2086/iframe resize on page load

### DIFF
--- a/course_info/static/css/course_info.css
+++ b/course_info/static/css/course_info.css
@@ -1,10 +1,13 @@
-td { border-width: thin; border-style: solid; border-color: #dbdbdb ; padding: 5px; }
-.course_info_textHeader1  {font-weight: bold; font-size: 16px;}
-.course_info_textHeader2  {font-weight: bold; font-size: 13px; font-color: red; }
-.course-info-widget-field-list {
-    width: 50%;
+td {
+    border: thin solid #dbdbdb;
+    padding: 5px;
 }
+
 /* Fixes Save button .pull-right removing bottom margin of editor main div */
 .course-info-edit-form {
     margin-bottom: 1em;
+}
+
+.course-info-widget-field-list {
+    width: 100%;
 }

--- a/course_info/templates/course_info/editor.html
+++ b/course_info/templates/course_info/editor.html
@@ -95,7 +95,9 @@
             {# https://canvas.instructure.com/doc/api/file.editor_button_tools.html #}
             <input type="hidden" id="return_type"   name="return_type"   value="iframe" />
             <input type="hidden" id="widget_url"    name="url"           value="" />
-            <input type="hidden" id="widget_height" name="height"        value="43em" />
+            {# this height is for the embedded 'media' placeholder in the rich #}
+            {# text editor view; will be resized later via javascript #}
+            <input type="hidden" id="widget_height" name="height"        value="200px" />
             <input type="hidden"                    name="width"         value="100%" />
             <input type="hidden"                    name="title"         value="Course Info" />
             <input type="hidden"                    name="id"            value="InfoFrame" />

--- a/course_info/templates/course_info/widget.html
+++ b/course_info/templates/course_info/widget.html
@@ -3,6 +3,30 @@
 {% block extra_head %}
     <base target="_blank">
 {% endblock %}
+{% block extra_js %}
+  <script type="text/javascript" charset="utf8">
+    function getOffsetHeightWithMargins() {
+      var
+        docStyle = document.defaultView.getComputedStyle(document.body, null),
+        docMarginTop = parseInt(docStyle['marginTop'], 10),
+        docMarginBottom = parseInt(docStyle['marginBottom'], 10);
+      return document.body.offsetHeight + docMarginTop + docMarginBottom;
+    }
+
+    function resizeIframe() {
+      window.parent.postMessage(
+        {
+          request: 'changeHeight',
+          href: document.location.href,
+          height: getOffsetHeightWithMargins() + 'px'
+        },
+        '*'  // needs to match multiple canvas domains
+      );
+    }
+
+    setTimeout(resizeIframe, 0);
+  </script>
+{% endblock %}
 
 {% block content %}
     <div id="course_info_container" class="container-fluid">


### PR DESCRIPTION
Uses a small chunk of code to resize once, at load time (advantage: smaller amount of code for clients to load on initial global.js; disadvantage: iframe won't resize if user changes something on the page, or the page reflows).

Companion code required in global.js: https://github.com/harvard-canvas-branding/canvas-branding-global/pull/22
