### PR TITLE
Sprint 35 TLT-2157 Better handling of course instance lookup edge cases

### DIFF
--- a/canvas_course_info/requirements/aws.txt
+++ b/canvas_course_info/requirements/aws.txt
@@ -7,3 +7,4 @@ git+https://github.com/harvard-dce/django-auth-lti.git@dce-lti-py#egg=django-aut
 hiredis==0.2.0
 redis==2.10.3
 requests==2.8.1
+voluptuous==0.8.7

--- a/canvas_course_info/requirements/aws.txt
+++ b/canvas_course_info/requirements/aws.txt
@@ -6,4 +6,4 @@ git+https://github.com/harvard-dce/dce_lti_py.git@v0.7.4#egg=dce-lti-py==0.7.4
 git+https://github.com/harvard-dce/django-auth-lti.git@dce-lti-py#egg=django-auth-lti==1.0
 hiredis==0.2.0
 redis==2.10.3
-requests==2.5.0
+requests==2.8.1

--- a/canvas_course_info/requirements/aws.txt
+++ b/canvas_course_info/requirements/aws.txt
@@ -1,9 +1,7 @@
 Django==1.7.1
 dj-static==0.0.6
-django-braces==1.3.1
 django-redis-cache==1.5.3
 django-toolbelt==0.0.1
-drest==0.9.12
 git+https://github.com/harvard-dce/dce_lti_py.git@v0.7.4#egg=dce-lti-py==0.7.4
 git+https://github.com/harvard-dce/django-auth-lti.git@dce-lti-py#egg=django-auth-lti==1.0
 hiredis==0.2.0

--- a/course_info/icommons.py
+++ b/course_info/icommons.py
@@ -38,6 +38,7 @@ class ICommonsApi(object):
             response.raise_for_status()
         except Exception as e:
             logger.exception(u'Error getting {}: {}'.format(url, response.text))
+            raise
         return response.json()
 
     def _get_course_instances(self, course_instance_id=None, **kwargs):

--- a/course_info/icommons.py
+++ b/course_info/icommons.py
@@ -5,6 +5,7 @@ import urlparse
 import requests
 from django.core.cache import cache
 from canvas_course_info.settings import aws as settings
+from voluptuous import All, Invalid, Range, Required, Schema, ALLOW_EXTRA
 
 
 logger = logging.getLogger(__name__)
@@ -13,42 +14,83 @@ CACHE_KEY_COURSE_BY_CANVAS_COURSE_ID = 'course-by-canvas-course-id-{}'
 CACHE_KEY_COURSE_BY_COURSE_INSTANCE_ID = 'course-by-course-instance-id-{}'
 CACHE_KEY_SCHOOL_BY_SCHOOL_ID = 'school-by-school-id-{}'
 
+# this isn't a full description of the resources, just what we're going to
+# expect to be in them within this library
+def url(value):
+    return bool(re.search('^https?://', value))
+
+course_instance_schema = Schema({
+    Required('course_instance_id'): All(int, Range(min=1)),
+    Required('primary_xlist_instances'): [All(basestring, url)],
+}, extra=ALLOW_EXTRA)
+
+school_schema = Schema({
+    Required('title_long'): basestring,
+}, extra=ALLOW_EXTRA)
+
+
+class ICommonsApiValidationError(RuntimeError):
+    pass
 
 class ICommonsApi(object):
-    def __init__(self, icommons_base_url=None, access_token=None):
-        if not icommons_base_url:
-            icommons_base_url = settings.ICOMMONS_BASE_URL
-        if not access_token:
-            access_token = settings.ICOMMONS_API_TOKEN
+    def __init__(self, icommons_base_url=settings.ICOMMONS_BASE_URL,
+                 access_token=settings.ICOMMONS_API_TOKEN):
         api_path = settings.ICOMMONS_API_PATH
 
-        self.base_url = '/'.join((icommons_base_url.rstrip('/'),
-                                  api_path.strip('/'))) + '/'
+        # we want to keep the full base url and append the api_path.  to get
+        # urljoin to do that, we need to ensure the base url has a trailing /,
+        # and that the path doesn't have a leading /.
+        self.base_url = urlparse.urljoin(icommons_base_url.rstrip('/') + '/',
+                                         api_path.lstrip('/'))
         self.session = requests.Session()
         self.session.headers = {'Authorization': 'Token %s' % access_token}
         self.session.params = {'format': 'json'}
 
-    def _get_objects_by_url(self, url, **kwargs):
+    def _get_resource_by_url(self, url, **kwargs):
         response = self.session.get(url, params=kwargs)
         try:
             response.raise_for_status()
-        except Exception as e:
+        except Exception:
             logger.exception(u'Error getting {}: {}'.format(url, response.text))
             raise
         return response.json()
 
-    def _get_objects(self, type_, id_, **kwargs):
+    def _get_resource(self, type_, id_, **kwargs):
         path = '{}/'.format(type_)
         if id_:
             path += '{}/'.format(id_)
         url = urlparse.urljoin(self.base_url, path)
-        return self._get_objects_by_url(url, **kwargs)
+        return self._get_resource_by_url(url, **kwargs)
 
     def _get_course_instances(self, course_instance_id=None, **kwargs):
-        return self._get_objects('course_instances', course_instance_id, **kwargs)
+        rv = self._get_resource('course_instances', course_instance_id, **kwargs)
+        try:
+            if 'results' in rv:
+                for instance in rv['results']:
+                    course_instance_schema(instance)
+            else:
+                course_instance_schema(rv)
+        except Invalid as e:
+            logger.exception(
+                u'Unable to validate course instance(s) %s returned from '
+                u'the icommons api.', rv)
+            raise ICommonsApiValidationError(str(e))
+        return rv
 
     def _get_schools(self, school_id=None, **kwargs):
-        return self._get_objects('schools', school_id, **kwargs)
+        rv = self._get_resource('schools', school_id, **kwargs)
+        try:
+            if 'results' in rv:
+                for instance in rv['results']:
+                    school_schema(instance)
+            else:
+                school_schema(rv)
+        except Invalid as e:
+            logger.exception(
+                u'Unable to validate school(s) %s returned from the icommons '
+                u'api.', rv)
+            raise ICommonsApiValidationError(str(e))
+        return rv
 
     def _parse_type_and_id_from_url(self, url):
         return url.replace(self.base_url, '').split('/')[:2]
@@ -64,8 +106,9 @@ class ICommonsApi(object):
                 log_msg = u'Caching course info for course_instance_id {}: {}'
                 logger.debug(log_msg.format(course_instance_id, json.dumps(course_info)))
                 cache.set(cache_key, course_info)
-            except Exception as e:
-                logger.exception(e.message)
+            except Exception:
+                logger.exception('Error retrieving course instance by id %s',
+                                 course_instance_id)
         return course_info
 
     def get_course_info_by_canvas_course_id(self, canvas_course_id):
@@ -99,7 +142,7 @@ class ICommonsApi(object):
         if school_info is None:
             school_info = {}
             try:
-                school_info = self._get_schools(school_id = school_id)
+                school_info = self._get_schools(school_id=school_id)
                 log_msg = u'Caching school info for school_id {}: {}'
                 logger.debug(log_msg.format(school_id, json.dumps(school_info)))
                 cache.set(cache_key, school_info)
@@ -126,7 +169,7 @@ class ICommonsApi(object):
                         u'for course instance %s',
                         primary_urls, course_instance)
                     return None
-                course_instance = self._get_objects_by_url(primary_urls[0])
+                course_instance = self._get_resource_by_url(primary_urls[0])
             return course_instance['course_instance_id']
 
         # we have multiple courses with the requested canvas course id, let's

--- a/course_info/tests.py
+++ b/course_info/tests.py
@@ -32,7 +32,7 @@ integration_test_course_info = {
 }
 
 
-@patch('course_info.views.ICommonsApi.from_request')
+@patch('course_info.views._api')
 class DisplayTests(TestCase):
     """
     Widget and editor should display correct values in the returned HTML
@@ -50,8 +50,8 @@ class DisplayTests(TestCase):
         Backend code should fetch info from the course and school
         helpers of the API wrapper
         """
-        api_mock.return_value.get_course_info_by_canvas_course_id = self.api_course_mock
-        api_mock.return_value.get_school_info = self.api_school_mock
+        api_mock.get_course_info_by_canvas_course_id = self.api_course_mock
+        api_mock.get_school_info = self.api_school_mock
         mock_school_id = mock_course_info['course']['school_id']
 
         client = Client(HTTP_REFERER=self.referer_string)
@@ -65,8 +65,8 @@ class DisplayTests(TestCase):
         Should show full school name and the course code (without the
         leading school short code, if present in registrar_code_display field)
         """
-        api_mock.return_value.get_course_info_by_canvas_course_id = self.api_course_mock
-        api_mock.return_value.get_school_info = self.api_school_mock
+        api_mock.get_course_info_by_canvas_course_id = self.api_course_mock
+        api_mock.get_school_info = self.api_school_mock
 
         client = Client(HTTP_REFERER=self.referer_string)
         response = client.get('/course_info/widget.html?f=course.registrar_code_display')
@@ -84,7 +84,7 @@ class DisplayTests(TestCase):
 
     def test_widget_multiple_fields(self, api_mock):
         """ Widget should display only the fields requested """
-        api_mock.return_value.get_course_info_by_canvas_course_id = self.api_course_mock
+        api_mock.get_course_info_by_canvas_course_id = self.api_course_mock
         query = 'f=title&f=term.display_name'
         client = Client(HTTP_REFERER=self.referer_string)
         response = client.get('/course_info/widget.html?{}'.format(query))
@@ -94,7 +94,7 @@ class DisplayTests(TestCase):
 
     def test_widget_partial_fields(self, api_mock):
         """ Widget should display only the fields with registrar data """
-        api_mock.return_value.get_course_info_by_canvas_course_id = self.api_course_mock
+        api_mock.get_course_info_by_canvas_course_id = self.api_course_mock
         query = 'f=exam_group&f=term.display_name'
         client = Client(HTTP_REFERER=self.referer_string)
         response = client.get('/course_info/widget.html?{}'.format(query))
@@ -103,7 +103,7 @@ class DisplayTests(TestCase):
 
     def test_editor_partial_field_data(self, api_mock):
         """ Editor should display all fields and note those without data """
-        api_mock.return_value.get_course_info = self.api_course_mock
+        api_mock.get_course_info = self.api_course_mock
         post_body = {'lis_course_offering_sourcedid': '0000'}
         request = self.factory.post('/', post_body)
         response = editor(request)

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
-from icommons import ICommonsApi
+from icommons import ICommonsApi, ICommonsApiValidationError
 
 
 _api = ICommonsApi()


### PR DESCRIPTION
Naturally, this is really two changes here:
- Get rid of drest, just use requests to access the icommons api
- Better handling of edge cases in course instance lookup
  - Handle the case where a secondary course correctly has its canvas_course_id set, but the primary doesn't.
  - Be more paranoid about verifying that all the course instances with the same canvas_course_id agree on the primary course instance id.

Might be easier to read this as a series of changes, rather than a single big change.  The first two are the refactor to replace drest with requests.  The last one is the edge case cleanup.
