### PR TITLE
fixes issue where a course with a single primary was being incorrectl…

### DIFF
--- a/course_info/icommons.py
+++ b/course_info/icommons.py
@@ -186,9 +186,10 @@ class ICommonsApi(object):
                     return None
                 _, id_ = self._parse_type_and_id_from_url(
                              ci['primary_xlist_instances'][0])
-                primary_cids.add(id_)
+                primary_cids.add(id_)  # unicode string
             else:
-                primary_cids.add(ci['course_instance_id'])
+                # must also be unicode string to match any dupes found above
+                primary_cids.add(u'{}'.format(ci['course_instance_id']))
         if len(primary_cids) == 1:
             return primary_cids.pop()
         elif len(primary_cids) == 0:


### PR DESCRIPTION
…y flagged as having multiple primaries.

One method stored CID as integer in the set of possible primaries, the other method stored it as a string, so the same CID was being stored as two separate objects in the set.
