### PR TITLE
Sprint 37 TLT-2249 Stop html escaping some course info fields

### DIFF
--- a/course_info/templates/course_info/editor.html
+++ b/course_info/templates/course_info/editor.html
@@ -75,11 +75,7 @@
                       <strong>{{ field.label }}:</strong>
                     </label>
                     {% if field.value %}
-                      {% if field.key in textarea_fields %}
-                        <textarea class="form-control" rows="1" disabled>{{ field.value }}</textarea>
-                      {% else %}
-                        {{ field.value }}
-                      {% endif %}
+                      {{ field.value }}
                     {% else %}
                       Field not populated by registrar
                     {% endif %}

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -25,8 +25,9 @@ _FIELD_DETAILS = {
     'location': {'label': 'Location', 'order': 5},
     'meeting_time': {'label': 'Meeting Time', 'order': 6},
     'exam_group': {'label': 'Exam Group', 'order': 7},
-    'description': {'label': 'Course Description', 'order': 8},
-    'notes': {'label': 'Notes', 'order': 9},
+    'description': {'label': 'Course Description', 'order': 8,
+                    'contains_html': True},
+    'notes': {'label': 'Notes', 'order': 9, 'contains_html': True},
 }
 _ORDERED_FIELD_NAMES = [
     f[0] for f in sorted(_FIELD_DETAILS.iteritems(), key=lambda f: f[1]['order'])
@@ -145,7 +146,9 @@ def _course_context(request, requested_keys, show_empty_fields=False,
         value = _get_field_value_for_key(key, course_info)
         if value or show_empty_fields:
             field = {'key': key, 'label': _FIELD_DETAILS[key]['label'],
-                     'value': mark_safe(value)}
+                     'value': value}
+            if _FIELD_DETAILS[key].get('contains_html', False):
+                field['value'] = mark_safe(field['value'])
             context['fields'].append(field)
 
     try:

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -193,7 +193,6 @@ def editor(request):
                                      course_instance_id=course_instance_id)
     course_context['launch_presentation_return_url'] = \
         request.POST.get('launch_presentation_return_url')
-    course_context['textarea_fields'] = ['description', 'notes']
     return render(request, 'course_info/editor.html', course_context)
 
 

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -24,8 +24,7 @@ _FIELD_DETAILS = {
     'location': {'label': 'Location', 'order': 5},
     'meeting_time': {'label': 'Meeting Time', 'order': 6},
     'exam_group': {'label': 'Exam Group', 'order': 7},
-    'description': {'label': 'Course Description', 'order': 8,
-                    'contains_html': True},
+    'description': {'label': 'Course Description', 'order': 8},
     'notes': {'label': 'Notes', 'order': 9},
 }
 _ORDERED_FIELD_NAMES = [
@@ -128,9 +127,8 @@ def _course_context(request, requested_keys, show_empty_fields=False,
     for key in [k for k in _ORDERED_FIELD_NAMES if k in requested_keys]:
         value = _get_field_value_for_key(key, course_info)
         if value or show_empty_fields:
-            field = {'key': key, 'label': _FIELD_DETAILS[key]['label'], 'value': value}
-            if _FIELD_DETAILS[key].get('contains_html', False):
-                field['value'] = mark_safe(field['value'])
+            field = {'key': key, 'label': _FIELD_DETAILS[key]['label'],
+                     'value': mark_safe(value)}
             context['fields'].append(field)
 
     try:

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.utils.safestring import mark_safe
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
@@ -15,7 +16,7 @@ from icommons import ICommonsApi, ICommonsApiValidationError
 
 _api = ICommonsApi()
 _logger = logging.getLogger(__name__)
-_FIELD_LABEL_MAP = {
+_FIELD_DETAILS = {
     'title': {'label': 'Course Title', 'order': 1},
     'course.registrar_code_display': {'label': 'Course Code', 'order': 2},
     'term.display_name': {'label': 'Term', 'order': 3},
@@ -23,11 +24,12 @@ _FIELD_LABEL_MAP = {
     'location': {'label': 'Location', 'order': 5},
     'meeting_time': {'label': 'Meeting Time', 'order': 6},
     'exam_group': {'label': 'Exam Group', 'order': 7},
-    'description': {'label': 'Course Description', 'order': 8},
+    'description': {'label': 'Course Description', 'order': 8,
+                    'contains_html': True},
     'notes': {'label': 'Notes', 'order': 9},
 }
 _ORDERED_FIELD_NAMES = [
-    f[0] for f in sorted(_FIELD_LABEL_MAP.iteritems(), key=lambda f: f[1]['order'])
+    f[0] for f in sorted(_FIELD_DETAILS.iteritems(), key=lambda f: f[1]['order'])
 ]
 _REFERER_COURSE_ID_RE = re.compile('^.+/courses/(?P<canvas_course_id>\d+)(?:$|.+$)')
 
@@ -126,7 +128,9 @@ def _course_context(request, requested_keys, show_empty_fields=False,
     for key in [k for k in _ORDERED_FIELD_NAMES if k in requested_keys]:
         value = _get_field_value_for_key(key, course_info)
         if value or show_empty_fields:
-            field = {'key': key, 'label': _FIELD_LABEL_MAP[key]['label'], 'value': value}
+            field = {'key': key, 'label': _FIELD_DETAILS[key]['label'], 'value': value}
+            if _FIELD_DETAILS[key].get('contains_html', False):
+                field['value'] = mark_safe(field['value'])
             context['fields'].append(field)
 
     try:
@@ -156,7 +160,7 @@ def widget(request):
         canvas_course_id = None
 
     # field names are sent as URL params f=field_name when widget is 'launched'
-    field_names = [f for f in request.GET.getlist('f') if f in _FIELD_LABEL_MAP.keys()]
+    field_names = [f for f in request.GET.getlist('f') if f in _FIELD_DETAILS.keys()]
     course_context = _course_context(request, field_names, canvas_course_id=canvas_course_id)
 
     populated_fields = [f for f in course_context['fields'] if f['value']]


### PR DESCRIPTION
Per devops, we support embedded HTML in the description and notes fields.

Also, stop embedding the `description` and `notes` fields in a `textarea` in the widget, so the users get a better idea of what the final result will look like.
