### PR TITLE
Sprint 37 TLT-2249 Add default SECRET_KEY to make jenkins happy

### DIFF
--- a/canvas_course_info/settings/base.py
+++ b/canvas_course_info/settings/base.py
@@ -90,14 +90,8 @@ LTI_APPS = {
     }
 }
 
-# Trying to copy the env(required=True) functionality
-SECRET_KEY = SECURE_SETTINGS['django_secret_key']
-# if SECRET_KEY:
-#     pass
-# else:
-#     raise KeyError
+SECRET_KEY = SECURE_SETTINGS.get('django_secret_key', 'changeme')
 
-#
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',


### PR DESCRIPTION
okay, really, it's to allow for running in environments with an empty
secure.py, but it sounds better this way.
