### PR TITLE
Remove the "id" input field to fix the problem reported in INC01795248

### DIFF
--- a/course_info/templates/course_info/editor.html
+++ b/course_info/templates/course_info/editor.html
@@ -96,7 +96,7 @@
             <input type="hidden" id="widget_height" name="height"        value="200px" />
             <input type="hidden"                    name="width"         value="100%" />
             <input type="hidden"                    name="title"         value="Course Info" />
-            <input type="submit" id="iframe_submit" name="iframe_submit" value="Save" class="btn btn-primary pull-right" />
+            <button onclick="this.form.submit()" class="btn btn-primary pull-right">Save</button>
         </form>
         <br/>
     </div>

--- a/course_info/templates/course_info/editor.html
+++ b/course_info/templates/course_info/editor.html
@@ -96,7 +96,6 @@
             <input type="hidden" id="widget_height" name="height"        value="200px" />
             <input type="hidden"                    name="width"         value="100%" />
             <input type="hidden"                    name="title"         value="Course Info" />
-            <input type="hidden"                    name="id"            value="InfoFrame" />
             <input type="submit" id="iframe_submit" name="iframe_submit" value="Save" class="btn btn-primary pull-right" />
         </form>
         <br/>


### PR DESCRIPTION
This PR removes the "id" input tag from the editor form; including that parameter in the form submission to Canvas was causing the embedding workflow to break.  

As far as I can tell that parameter is not necessary for the proper function of the tool. 

Fixes error reported in INC01795248. 
