### PR TITLE
TLT-2814: bugfix - show multiple instructors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ secure.py
 gunicorn.py
 http_static
 gunicorn.py
+
+# Django stuff:
+*.log

--- a/canvas_course_info/requirements/aws.txt
+++ b/canvas_course_info/requirements/aws.txt
@@ -1,10 +1,9 @@
-Django==1.7.1
+Django==1.8.15
 dj-static==0.0.6
-django-redis-cache==1.5.3
-django-toolbelt==0.0.1
+django-redis-cache==1.7.0
 git+https://github.com/harvard-dce/dce_lti_py.git@v0.7.4#egg=dce-lti-py==0.7.4
 git+https://github.com/harvard-dce/django-auth-lti.git@dce-lti-py#egg=django-auth-lti==1.0
 hiredis==0.2.0
-redis==2.10.3
-requests==2.8.1
+redis==2.10.5
+requests==2.11.1
 voluptuous==0.8.7

--- a/canvas_course_info/requirements/local.txt
+++ b/canvas_course_info/requirements/local.txt
@@ -1,9 +1,9 @@
 # local environment requirements, including base requirements
 -r aws.txt
-PyVirtualDisplay==0.1.5
-ddt==1.0.0
-django-debug-toolbar==1.4
-django-sslserver==0.15
-mock==1.3.0
-selenium==2.48.0
-xlrd==0.9.4
+ddt==1.1.0
+django-debug-toolbar==1.5
+django-sslserver==0.19
+mock==2.0.0
+pyvirtualdisplay==0.2
+selenium==2.53.0
+xlrd==1.0.0

--- a/canvas_course_info/settings/local.py
+++ b/canvas_course_info/settings/local.py
@@ -1,4 +1,5 @@
-# to activate these settings, execute ./manage.py runserver --settings=canvas_course_info.settings.local
+# to activate these settings, execute
+# ./manage.py runserver --settings=canvas_course_info.settings.local
 
 from .base import *
 from logging.config import dictConfig
@@ -16,12 +17,19 @@ DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
 }
 
-# Example ID for local dev: won't be getting a real course instance id from LTI launch params.
+# Example ID for local dev: won't be getting a real course instance id from LTI
+# launch params.
 COURSE_INSTANCE_ID = SECURE_SETTINGS.get('course_instance_id')
 if COURSE_INSTANCE_ID:
     COURSE_INSTANCE_ID = str(COURSE_INSTANCE_ID)
 
-CANVAS_URL = SECURE_SETTINGS.get('canvas_url', 'https://canvas.harvard.edu')
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
+CANVAS_URL = SECURE_SETTINGS.get('canvas_url', 'https://canvas.dev.harvard.edu')
 
 # Allows the REST API passthrough to successfully negotiate an SSL session
 # with an unverified certificate, e.g. the one that ships with django-sslserver

--- a/course_info/tests.py
+++ b/course_info/tests.py
@@ -259,6 +259,7 @@ class DisplayTests(TestCase):
         # assert that the response doesn't contains 'Course Instructors'label
         self.assertNotContains(response, 'Course Instructors:')
 
+
 class IntegrationTests(TestCase):
     """
     These tests will ensure that the widget (and by extension, the iCommon API)
@@ -269,6 +270,7 @@ class IntegrationTests(TestCase):
     """
     @classmethod
     def setUpClass(cls):
+        super(IntegrationTests, cls).setUpClass()
         cls.base_url = 'https://canvas.dev.harvard.edu/'
         cls.referer_header = '{}/courses/{}'.format(
             cls.base_url,

--- a/course_info/tests.py
+++ b/course_info/tests.py
@@ -1,5 +1,8 @@
-from django.test import Client, TestCase, RequestFactory
-from mock import patch, MagicMock
+from mock import MagicMock, patch
+
+from django.test import Client, RequestFactory, TestCase
+
+from icommons import ICommonsApi
 from views import editor, sort_and_format_instructor_display
 
 # todo: docstrings
@@ -271,7 +274,7 @@ class IntegrationTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super(IntegrationTests, cls).setUpClass()
-        cls.base_url = 'https://canvas.dev.harvard.edu/'
+        cls.base_url = 'https://canvas.dev.harvard.edu'
         cls.referer_header = '{}/courses/{}'.format(
             cls.base_url,
             integration_test_course_info['canvas_course_id']
@@ -290,3 +293,40 @@ class IntegrationTests(TestCase):
         response = c.get(self.test_url)
 
         self.assertContains(response, integration_test_course_info['school_display'])
+
+
+@patch('course_info.icommons.requests.Session.get')
+class ApiTests(TestCase):
+    def setUp(self):
+        self.test_ci_id = 1
+        super(ApiTests, self).setUp()
+
+    def test_instructor_list_no_pages(self, session_get_mock):
+        """ fetching collection with one page should show results in a list """
+        test_data = {'results': mock_staff_data_from_api}
+        session_get_mock.return_value.json.return_value = test_data
+        api = ICommonsApi()
+
+        instructors = api.get_course_info_instructor_list(
+            course_instance_id=self.test_ci_id)
+
+        self.assertEqual(len(instructors), 5)
+        self.assertEqual(session_get_mock.call_count, 1)
+
+    def test_instructor_list_multiple_pages(self, session_get_mock):
+        """ fetching collection should return all pages of results in a list """
+        def results_generator(page_count=1):
+            for index in range(page_count):
+                yield {'next': 'fakeurl' if index < page_count-1 else None,
+                       'results': [mock_staff_data_from_api[index]]}
+
+        test_page_count = 3  # i.e. instructor count (1 per page)
+        session_get_mock.return_value.json.side_effect = [
+            x for x in results_generator(test_page_count)]
+        api = ICommonsApi()
+
+        instructors = api.get_course_info_instructor_list(
+            course_instance_id=self.test_ci_id)
+
+        self.assertEqual(len(instructors), test_page_count)
+        self.assertEqual(session_get_mock.call_count, test_page_count)


### PR DESCRIPTION
Shows all instructors for courses without registrar-fed instructor display information.
- fetches all pages of results from REST API to build the instructor list
- ups the default page size to 100 records for REST API calls to reduce network overhead
- updates local and base/aws requirements, removes django-toolbelt requirement (so may not work anymore with heroku)
