### PR TITLE
Update psycopg2

### DIFF
--- a/canvas_course_info/requirements/aws.txt
+++ b/canvas_course_info/requirements/aws.txt
@@ -4,8 +4,8 @@ git+https://github.com/harvard-dce/dce_lti_py.git@v0.7.4#egg=dce-lti-py==0.7.4
 git+https://github.com/harvard-dce/django-auth-lti.git@dce-lti-py#egg=django-auth-lti==1.0
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.5.3#egg=django-icommons-ui==1.5.3
 hiredis==0.2.0
-psycopg2==2.7.1
-redis==2.10.5
-requests==2.13.0
+psycopg2==2.7.7
+redis==2.10.6
+requests==2.22.0
 voluptuous==0.9.3
-gunicorn==19.7.1
+gunicorn==19.10.0


### PR DESCRIPTION
This is to update psycopg2 from 2.7.1 to resolve an issue on ubuntu 18.04 when using that version. Installing any version newer than 2.7.3 seems to resolve it.

Error:

```
django.core.exceptions.ImproperlyConfigured: Error loading psycopg2 module: python2.7/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference
```

This also updates the versions of `redis`, `requests`, and `gunicorn` for good measure.

@cmurtaugh @sapnamysore @cmsnowden any objections to this change?