### PR TITLE
Task/tlt 4938/idkjay/add primary instructor

### DIFF
--- a/course_info/icommons.py
+++ b/course_info/icommons.py
@@ -148,25 +148,21 @@ class ICommonsApi(object):
         return rv
 
     def _course_info_instructor_list(self, course_instance_id, **kwargs):
-        instructors = []
+        instructors = None
         people_list = self._get_resource('course_instances', course_instance_id,
                                          'people', collection=True, **kwargs)
         try:
+            instructors = []
             for person in people_list:
                 course_person_schema(person)
-                role_id = person.get('role', {}).get('role_id')
-                if role_id in INSTRUCTOR_ROLE_IDS:
+                if person.get('role', {}).get('role_id') in INSTRUCTOR_ROLE_IDS:
                     instructors.append(person)
-
-            # Sort instructors so that users with the Primary Instructor role come listed before those with the Instructor role
-            instructors.sort(key=lambda p: (p.get('role', {}).get('role_id') != 19, p.get('role', {}).get('role_id')))
 
         except Invalid as e:
             logger.exception(
                 'Unable to validate course instance(s) %s returned from '
                 'the icommons api.', people_list)
             raise ICommonsApiValidationError(str(e))
-         
         return instructors
 
     def _parse_type_and_id_from_url(self, url):

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -235,9 +235,12 @@ def sort_and_format_instructor_display(course_instructor_list):
     # Note:  when seniority_sort is None, it was getting precedence over 1(eg: null, 1, 2).  So in such cases,
     # it is being set to a large number (picked 100) so it is lower in the sorting order. [1, 2, ...null(set to 100)]
     # Also, x.get('seniority_sort', {}) handles null condition  but for None, needed to have the explicit check
-    course_instructor_list.sort(key=lambda x: (x.get('role', {}).get('role_id'),
-                                               100 if x.get('seniority_sort') is None else x.get('seniority_sort', {}),
-                                               x.get('profile', {}).get('name_last')))
+    course_instructor_list.sort(key=lambda x: (
+        x.get('role', {}).get('role_id') != 19,  # Primary Instructor (19) should come first
+        x.get('role', {}).get('role_id'),  # Other role IDs in ascending order
+        100 if x.get('seniority_sort') is None else x.get('seniority_sort', {}),  # Handle None values
+        x.get('profile', {}).get('name_last')  # Sort by last name
+    ))
 
     num_instructors = len(course_instructor_list)
 


### PR DESCRIPTION
This is the PR for [TLT-4938](https://at-harvard.atlassian.net/jira/software/c/projects/TLT/boards/310?selectedIssue=TLT-4938).

- Added Primary Instructor (role ID 19) to the list of instructors in canvas_course_info.
  - Secondary Instructor (role ID 20) was not added yet according to the story.
- Added custom sorting to allow users with the Primary Instructor role show in the list before users with the Instructor role.
- Deployed in QA

(need to install proper tool for testing)